### PR TITLE
(feat) Wrap empty state tile in a layer for better contrast

### DIFF
--- a/src/components/empty-data/empty-data.component.tsx
+++ b/src/components/empty-data/empty-data.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Tile } from "@carbon/react";
+import { Layer, Tile } from "@carbon/react";
 import { EmptyDataIllustration } from "@openmrs/esm-patient-common-lib/src/empty-state/index";
 
 import styles from "./empty-data.style.scss";
@@ -11,12 +11,14 @@ export interface EmptyDataProps {
 
 const EmptyData: React.FC<EmptyDataProps> = (props) => {
   return (
-    <Tile className={styles.tile}>
-      <EmptyDataIllustration />
-      <p className={styles.content}>
-        There are no {props.displayText.toLowerCase()} to display
-      </p>
-    </Tile>
+    <Layer>
+      <Tile className={styles.tile}>
+        <EmptyDataIllustration />
+        <p className={styles.content}>
+          There are no {props.displayText.toLowerCase()} to display
+        </p>
+      </Tile>
+    </Layer>
   );
 };
 

--- a/src/components/saved-cohorts/saved-cohorts.component.tsx
+++ b/src/components/saved-cohorts/saved-cohorts.component.tsx
@@ -131,7 +131,7 @@ const SavedCohorts: React.FC<SavedCohortsProps> = ({ onViewCohort }) => {
           totalItems={cohorts.length}
         />
       )}
-      {!cohorts.length && <EmptyData displayText="cohorts" />}
+      {!cohorts.length && <EmptyData displayText={t("cohorts", "cohorts")} />}
     </div>
   );
 };

--- a/src/components/saved-queries/saved-queries.component.tsx
+++ b/src/components/saved-queries/saved-queries.component.tsx
@@ -131,7 +131,7 @@ const SavedQueries: React.FC<SavedQueriesProps> = ({ onViewQuery }) => {
           totalItems={queries.length}
         />
       )}
-      {!queries.length && <EmptyData displayText="queries" />}
+      {!queries.length && <EmptyData displayText={t("queries", "queries")} />}
     </div>
   );
 };

--- a/src/components/search-history/search-history.component.tsx
+++ b/src/components/search-history/search-history.component.tsx
@@ -146,7 +146,7 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({
           totalItems={searchResults.length}
         />
       )}
-      {!searchResults.length && <EmptyData displayText="history" />}
+      {!searchResults.length && <EmptyData displayText={t("data", "data")} />}
       <ComposedModal
         size={"sm"}
         open={isClearHistoryModalVisible}

--- a/src/components/search-history/search-history.test.tsx
+++ b/src/components/search-history/search-history.test.tsx
@@ -86,7 +86,7 @@ describe("Test the search history component", () => {
     );
 
     expect(
-      screen.getByText("There are no history to display")
+      screen.getByText("There are no data to display")
     ).toBeInTheDocument();
   });
 

--- a/src/components/search-results-table/search-results-table.component.tsx
+++ b/src/components/search-results-table/search-results-table.component.tsx
@@ -97,7 +97,7 @@ const SearchResultsTable: React.FC<SearchResultsTableProps> = ({
           totalItems={patients.length}
         />
       )}
-      {!patients.length && <EmptyData displayText="data" />}
+      {!patients.length && <EmptyData displayText={t("data", "data")} />}
     </div>
   );
 };


### PR DESCRIPTION
Wraps the empty state tiles in `Layer` components for better visual contrast. Also adds some missing translations and tweaks a test.


<img width="905" alt="Screenshot 2022-11-08 at 23 59 48" src="https://user-images.githubusercontent.com/8509731/200674262-a18382cc-ae64-4899-a779-8f7c220b7cd4.png">
