### PR TITLE
(chore) Fix release command

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -105,7 +105,7 @@ jobs:
           node-version: "16.x"
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
-      - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag latest
+      - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -105,7 +105,7 @@ jobs:
           node-version: "16.x"
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
-      - run: yarn publish --access public
+      - run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
Fixes the `release` job of our primary CI workflow as follows:

- Prepends the release command with a command that sets the `npmAuthToken`, which is necessary for publishing.
- Appends the publish command with the `latest` tag, which is what we're using for stable releases.