### PR TITLE
(chore) Fix pre-release job

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -84,7 +84,7 @@ jobs:
       - run: git add . && git commit -m "Prerelease version" --no-verify
 
       - name: Pre-release
-        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn npm publish --access public --tag next
+        run: yarn config set npmAuthToken "${NODE_AUTH_TOKEN}" && yarn publish --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 


### PR DESCRIPTION
This PR fixes the pre-release job in our primary CI workflow. More specifically, it configures the pre-release script to run `yarn publish` instead of `yarn npm publish` (which won't work in a non-Yarn 3 environment).