### PR TITLE
(fix) Add missing cohort builder admin page card extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,14 @@ export const importTranslation = require.context(
   "lazy"
 );
 
+export function startupApp() {}
+
 export const cohortBuilder = getAsyncLifecycle(
   () => import("./cohort-builder"),
   options
 );
 
-export function startupApp() {}
+export const cohortBuilderAdminPageCardLink = getAsyncLifecycle(
+  () => import("./cohort-builder-admin-link.component"),
+  options
+);

--- a/src/routes.json
+++ b/src/routes.json
@@ -18,7 +18,7 @@
     {
       "name": "system-administration-cohort-builder-card-link",
       "slot": "system-admin-page-card-link-slot",
-      "component": "cohortBuilder",
+      "component": "cohortBuilderAdminPageCardLink",
       "online": true,
       "offline": true
     }


### PR DESCRIPTION
Adds a missing extension for the cohort admin page card link component. Fixes an issue where the wrong component gets loaded in the System Administration page.