### PR TITLE
(feat) Synchronously load extensions and pages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import { getAsyncLifecycle } from "@openmrs/esm-framework";
+import { getSyncLifecycle } from "@openmrs/esm-framework";
+
+import cohortBuilderComponent from "./cohort-builder";
+import cohortBuilderAdminPageCardLinkComponent from "./cohort-builder-admin-link.component";
 
 const moduleName = "@openmrs/esm-cohort-builder";
 
@@ -16,12 +19,9 @@ export const importTranslation = require.context(
 
 export function startupApp() {}
 
-export const cohortBuilder = getAsyncLifecycle(
-  () => import("./cohort-builder"),
-  options
-);
+export const cohortBuilder = getSyncLifecycle(cohortBuilderComponent, options);
 
-export const cohortBuilderAdminPageCardLink = getAsyncLifecycle(
-  () => import("./cohort-builder-admin-link.component"),
+export const cohortBuilderAdminPageCardLink = getSyncLifecycle(
+  cohortBuilderAdminPageCardLinkComponent,
   options
 );


### PR DESCRIPTION
This PR modifies the dynamic imports for components in the entry point of this frontend module with the goal of loading those components sychronously so as to limit the number of chunks that the Webpack chunking algorithm creates. See https://o3-docs.openmrs.org/docs/migration-guide#6-tweak-component-imports-to-limit-the-number-of-webpack-chunks-created for more information.