### PR TITLE
(chore) Reduce timeout to 15 minutes in E2E test CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    timeout-minutes: 16
+    timeout-minutes: 15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 16
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Reduces the `timeout` value from 1 hour to 15 minutes in the E2E test CI workflow.