### PR TITLE
(refactor) Replace usages of /ws/rest/v1 with restBaseUrl

### DIFF
--- a/src/cohort-builder.resources.ts
+++ b/src/cohort-builder.resources.ts
@@ -1,4 +1,8 @@
-import { openmrsFetch, FetchResponse } from "@openmrs/esm-framework";
+import {
+  openmrsFetch,
+  FetchResponse,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 import useSWRImmutable from "swr/immutable";
 
 import { Patient, SearchParams, DropdownValue, Response } from "./types";
@@ -13,7 +17,7 @@ interface SearchResults {
 
 export const search = async (searchParams: SearchParams) => {
   const searchResults: FetchResponse<SearchResults> = await openmrsFetch(
-    "/ws/rest/v1/reportingrest/adhocquery?v=full",
+    `${restBaseUrl}/reportingrest/adhocquery?v=full`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -29,7 +33,7 @@ export const search = async (searchParams: SearchParams) => {
 export const useLocations = () => {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/location", openmrsFetch);
+  }>(`${restBaseUrl}/location`, openmrsFetch);
 
   const locations: DropdownValue[] = [];
   data?.data.results.map((location: Response, index: number) => {
@@ -49,7 +53,7 @@ export const useLocations = () => {
 
 export const getDataSet = async (queryID: string) => {
   const results: FetchResponse<SearchResults> = await openmrsFetch(
-    `/ws/rest/v1/reportingrest/dataSet/${queryID}`,
+    `${restBaseUrl}/reportingrest/dataSet/${queryID}`,
     {
       method: "GET",
     }
@@ -67,7 +71,7 @@ export const getDataSet = async (queryID: string) => {
 
 export const getCohortMembers = async (cohortId: string) => {
   const results: FetchResponse<SearchResults> = await openmrsFetch(
-    `/ws/rest/v1/cohort/${cohortId}/member?v=full`,
+    `${restBaseUrl}/cohort/${cohortId}/member?v=full`,
     {
       method: "GET",
     }

--- a/src/components/saved-cohorts/saved-cohorts.resources.ts
+++ b/src/components/saved-cohorts/saved-cohorts.resources.ts
@@ -1,4 +1,8 @@
-import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import {
+  FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 
 import { Cohort, DefinitionDataRow } from "../../types";
 
@@ -7,7 +11,7 @@ import { Cohort, DefinitionDataRow } from "../../types";
  */
 export async function getCohorts(): Promise<DefinitionDataRow[]> {
   const response: FetchResponse<{ results: Cohort[] }> = await openmrsFetch(
-    "/ws/rest/v1/cohort?v=full",
+    `${restBaseUrl}/cohort?v=full`,
     {
       method: "GET",
     }
@@ -30,7 +34,7 @@ export async function getCohorts(): Promise<DefinitionDataRow[]> {
 
 export const onDeleteCohort = async (cohort: string) => {
   const result: FetchResponse = await openmrsFetch(
-    `/ws/rest/v1/cohort/${cohort}`,
+    `${restBaseUrl}/cohort/${cohort}`,
     {
       method: "DELETE",
     }

--- a/src/components/saved-queries/saved-queries.resources.ts
+++ b/src/components/saved-queries/saved-queries.resources.ts
@@ -1,4 +1,8 @@
-import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import {
+  FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 
 import { Response, DefinitionDataRow } from "../../types";
 
@@ -7,7 +11,7 @@ import { Response, DefinitionDataRow } from "../../types";
  */
 export async function getQueries(): Promise<DefinitionDataRow[]> {
   const response: FetchResponse<{ results: Response[] }> = await openmrsFetch(
-    "/ws/rest/v1/reportingrest/dataSetDefinition?v=full",
+    `${restBaseUrl}/reportingrest/dataSetDefinition?v=full`,
     {
       method: "GET",
     }
@@ -30,7 +34,7 @@ export async function getQueries(): Promise<DefinitionDataRow[]> {
 
 export const deleteDataSet = async (queryID: string) => {
   const dataset: FetchResponse = await openmrsFetch(
-    `/ws/rest/v1/reportingrest/adhocdataset/${queryID}?purge=true`,
+    `${restBaseUrl}/reportingrest/adhocdataset/${queryID}?purge=true`,
     {
       method: "DELETE",
     }

--- a/src/components/search-by-concepts/search-concept/search-concept.resource.ts
+++ b/src/components/search-by-concepts/search-concept/search-concept.resource.ts
@@ -1,4 +1,8 @@
-import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import {
+  FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 
 import { Concept, DataType } from "../../../types";
 
@@ -22,7 +26,7 @@ interface Description {
  */
 export async function getConcepts(conceptName: String): Promise<Concept[]> {
   const searchResult: FetchResponse<{ results: ConceptResponse[] }> =
-    await openmrsFetch(`/ws/rest/v1/concept?v=full&q=${conceptName}`, {
+    await openmrsFetch(`${restBaseUrl}/concept?v=full&q=${conceptName}`, {
       method: "GET",
     });
 

--- a/src/components/search-by-drug-orders/search-by-drug-orders.resources.ts
+++ b/src/components/search-by-drug-orders/search-by-drug-orders.resources.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import useSWRImmutable from "swr/immutable";
 
 import { DropdownValue, Response } from "../../types";
@@ -11,7 +11,7 @@ import { DropdownValue, Response } from "../../types";
 export function useDrugs() {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/drug", openmrsFetch);
+  }>(`${restBaseUrl}/drug`, openmrsFetch);
 
   const results = useMemo(() => {
     const drugs: DropdownValue[] = [];
@@ -38,7 +38,7 @@ export function useDrugs() {
 export function useCareSettings() {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/caresetting", openmrsFetch);
+  }>(`${restBaseUrl}/caresetting`, openmrsFetch);
 
   const results = useMemo(() => {
     const careSettings: DropdownValue[] = [];

--- a/src/components/search-by-encounters/search-by-encounters.resources.ts
+++ b/src/components/search-by-encounters/search-by-encounters.resources.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import useSWRImmutable from "swr/immutable";
 
 import { DropdownValue, Response } from "../../types";
@@ -9,7 +9,7 @@ import { DropdownValue, Response } from "../../types";
 export const useForms = () => {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/form", openmrsFetch);
+  }>(`${restBaseUrl}/form`, openmrsFetch);
 
   const forms: DropdownValue[] = [];
   data?.data.results.map((form: Response, index: number) => {
@@ -33,7 +33,7 @@ export const useForms = () => {
 export const useEncounterTypes = () => {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/encountertype", openmrsFetch);
+  }>(`${restBaseUrl}/encountertype`, openmrsFetch);
 
   const encounterTypes: DropdownValue[] = [];
   data?.data.results.map((encounterType: Response, index: number) => {

--- a/src/components/search-by-enrollments/search-by-enrollments.resources.ts
+++ b/src/components/search-by-enrollments/search-by-enrollments.resources.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import useSWRImmutable from "swr/immutable";
 
 import { DropdownValue, Response } from "../../types";
@@ -13,7 +13,7 @@ interface ProgramsResponse extends Response {
 export function usePrograms() {
   const { data, error } = useSWRImmutable<{
     data: { results: ProgramsResponse[] };
-  }>("/ws/rest/v1/program", openmrsFetch);
+  }>(`${restBaseUrl}/program`, openmrsFetch);
 
   const programs: DropdownValue[] = [];
   data?.data.results.map((program: ProgramsResponse, index: number) => {

--- a/src/components/search-by-person-attributes/search-by-person-attributes.resource.ts
+++ b/src/components/search-by-person-attributes/search-by-person-attributes.resource.ts
@@ -1,4 +1,4 @@
-import { openmrsFetch } from "@openmrs/esm-framework";
+import { openmrsFetch, restBaseUrl } from "@openmrs/esm-framework";
 import useSWRImmutable from "swr/immutable";
 
 import { DropdownValue, Response } from "../../types";
@@ -9,7 +9,7 @@ import { DropdownValue, Response } from "../../types";
 export function usePersonAttributes() {
   const { data, error } = useSWRImmutable<{
     data: { results: Response[] };
-  }>("/ws/rest/v1/personattributetype", openmrsFetch);
+  }>(`${restBaseUrl}/personattributetype`, openmrsFetch);
 
   const personAttributes: DropdownValue[] = [];
   data?.data.results.map((personAttribute: Response, index: number) => {

--- a/src/components/search-history/search-history-options/search-history-options.resources.ts
+++ b/src/components/search-history/search-history-options/search-history-options.resources.ts
@@ -1,4 +1,8 @@
-import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import {
+  FetchResponse,
+  openmrsFetch,
+  restBaseUrl,
+} from "@openmrs/esm-framework";
 
 import { Cohort, Query } from "../../../types";
 
@@ -9,7 +13,7 @@ import { Cohort, Query } from "../../../types";
 export async function createCohort(
   cohort: Cohort
 ): Promise<FetchResponse<Cohort>> {
-  return await openmrsFetch("/ws/rest/v1/cohort", {
+  return await openmrsFetch(`${restBaseUrl}/cohort`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: cohort,
@@ -21,7 +25,7 @@ export async function createCohort(
  * @param query
  */
 export async function createQuery(query: Query): Promise<FetchResponse<Query>> {
-  return await openmrsFetch("/ws/rest/v1/reportingrest/adhocdataset", {
+  return await openmrsFetch(`${restBaseUrl}/reportingrest/adhocdataset`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: query,


### PR DESCRIPTION
**Summary**
Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the restBaseUrl variable instead. To enhances maintainability and flexibility of the API base URL configuration.

**Screenshots**
None

**Related Issue**
https://openmrs.atlassian.net/browse/O3-2815