### PR TITLE
(chore) Downgrade @actions/upload-artifact GitHub action

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      
+
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
@@ -55,7 +55,7 @@ jobs:
         run: docker stop $(docker ps -a -q)
 
       - name: Upload Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,7 @@ jobs:
       - run: yarn verify
       - run: yarn build
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: |
@@ -59,7 +59,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: |


### PR DESCRIPTION
This PR downgrades the [@actions/upload-artifact](https://github.com/actions/upload-artifact) GitHub Action. Changes to the action upstream necessitate tweaks to how we use it. I don't have the time to do the refactor now, so I'm electing to downgrade the action to the previous working version. This fixes the build, which is currently failing.